### PR TITLE
export front-matter

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "statements": 100
   },
   "dependencies": {
+    "camelize": "^1.0.0",
+    "except": "^0.1.3",
     "front-matter": "^2.1.0",
     "prismjs": "^1.5.1",
     "remarkable": "^1.6.2"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "except": "^0.1.3",
     "front-matter": "^2.1.0",
     "node-prismjs": "^0.1.0",
-    "prismjs": "^1.5.1",
     "remarkable": "^1.6.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "camelize": "^1.0.0",
     "except": "^0.1.3",
     "front-matter": "^2.1.0",
+    "node-prismjs": "^0.1.0",
     "prismjs": "^1.5.1",
     "remarkable": "^1.6.2"
   },

--- a/src/build.js
+++ b/src/build.js
@@ -1,4 +1,6 @@
 'use strict';
+const camelize = require('camelize');
+const except = require('except');
 
 /**
  * @typedef HTMLObject
@@ -20,6 +22,8 @@ module.exports = function build(markdown) {
     imports = markdown.imports || {},
     jsx = markdown.html.replace(/class=/g, 'className=');
 
+  const frontMatterAttributes = except(markdown.attributes, 'imports');
+
   for (const variable in imports) {
     // eslint-disable-next-line no-prototype-builtins
     if (imports.hasOwnProperty(variable)) {
@@ -30,7 +34,8 @@ module.exports = function build(markdown) {
   return `
 ${doImports}
 
-module.exports = function() {
+export const attributes = ${JSON.stringify(camelize(frontMatterAttributes))};
+export default function() {
   return (
     <div>
       ${jsx}

--- a/src/build.js
+++ b/src/build.js
@@ -19,7 +19,7 @@ module.exports = function build(markdown) {
 
   let doImports = 'import React from \'react\';\n';
   const
-    imports = markdown.imports || {},
+    imports = markdown.attributes.imports || {},
     jsx = markdown.html.replace(/class=/g, 'className=');
 
   const frontMatterAttributes = except(markdown.attributes, 'imports');

--- a/src/parser.js
+++ b/src/parser.js
@@ -2,12 +2,10 @@
 
 const
   frontMatter = require('front-matter'),
-  Prism = require('prismjs'),
+  Prism = require('node-prismjs'),
   Remarkable = require('remarkable'),
   escapeHtml = require('remarkable/lib/common/utils').escapeHtml,
   md = new Remarkable();
-
-require('prismjs/components/prism-jsx');
 
 /**
  * Wraps the code and jsx in an html component
@@ -83,7 +81,8 @@ function parseMarkdown(markdown) {
 
     const options = {
       highlight(code, lang) {
-        return Prism.highlight(code, Prism.languages[lang]);
+        const language = Prism.languages[lang] || Prism.languages.autoit;
+        return Prism.highlight(code, language);
       },
       xhtmlOut: true
     };

--- a/src/parser.js
+++ b/src/parser.js
@@ -103,7 +103,7 @@ function parseMarkdown(markdown) {
 
     try {
       html = md.render(markdown.body);
-      resolve({ html, imports: markdown.attributes.imports });
+      resolve({ html, attributes: markdown.attributes, imports: markdown.attributes.imports });
     } catch (err) {
       return reject(err);
     }

--- a/src/parser.js
+++ b/src/parser.js
@@ -103,7 +103,7 @@ function parseMarkdown(markdown) {
 
     try {
       html = md.render(markdown.body);
-      resolve({ html, attributes: markdown.attributes, imports: markdown.attributes.imports });
+      resolve({ html, attributes: markdown.attributes });
     } catch (err) {
       return reject(err);
     }

--- a/test/build.spec.js
+++ b/test/build.spec.js
@@ -36,4 +36,8 @@ describe('Build Component', () => {
     component.should.contain('import HelloWorld from \'./hello-world.js\';\n');
   });
 
+  it('exports the front-matter attributes', () => {
+    component.should.contain('export const attributes = {"testFrontMatter":"hello world"}');
+  });
+
 });

--- a/test/examples/hello-world.md
+++ b/test/examples/hello-world.md
@@ -1,4 +1,5 @@
 ---
+test-front-matter: 'hello world'
 imports:
   Button: './button.js'
   HelloWorld: './hello-world.js'

--- a/test/parser.spec.js
+++ b/test/parser.spec.js
@@ -51,19 +51,29 @@ describe('Parse Markdown', () => {
 </div>`);
   });
 
-  it('parses markdown with live code blocks', () =>
+  it('parses markdown with live code blocks', (done) => {
     parser.parse(mdExample).then(result => {
       result.html.should.contain(`<div class="run"><HelloWorld />
 <Button label="Hello World" />
 </div>`);
     })
-  );
+    .then(done)
+    .catch(done);
+  });
 
   it('parses markdown and created valid html for JSX', (done) => {
     const
       exampleCode = '![](myImage.png)';
     parser.parse(exampleCode).then(result => {
       result.html.should.equal('<p><img src="myImage.png" alt="" /></p>\n');
+    })
+    .then(done)
+    .catch(done);
+  });
+
+  it('provides the front-matter attributes', (done) => {
+    parser.parse(mdExample).then(result => {
+      result.attributes['test-front-matter'].should.equal('hello world');
     })
     .then(done)
     .catch(done);

--- a/test/parser.spec.js
+++ b/test/parser.spec.js
@@ -59,12 +59,14 @@ describe('Parse Markdown', () => {
     })
   );
 
-  it('parses markdown and created valid html for JSX', () => {
+  it('parses markdown and created valid html for JSX', (done) => {
     const
       exampleCode = '![](myImage.png)';
     parser.parse(exampleCode).then(result => {
-      result.html.should.ewual('<p><img src="myImage.png" alt="" /></p>\n');
-    });
+      result.html.should.equal('<p><img src="myImage.png" alt="" /></p>\n');
+    })
+    .then(done)
+    .catch(done);
   });
 
 });

--- a/test/parser.spec.js
+++ b/test/parser.spec.js
@@ -51,7 +51,7 @@ describe('Parse Markdown', () => {
 </div>`);
   });
 
-  it('parses markdown with live code blocks', (done) => {
+  it('parses markdown with live code blocks', done => {
     parser.parse(mdExample).then(result => {
       result.html.should.contain(`<div class="run"><HelloWorld />
 <Button label="Hello World" />
@@ -61,7 +61,7 @@ describe('Parse Markdown', () => {
     .catch(done);
   });
 
-  it('parses markdown and created valid html for JSX', (done) => {
+  it('parses markdown and created valid html for JSX', done => {
     const
       exampleCode = '![](myImage.png)';
     parser.parse(exampleCode).then(result => {
@@ -71,7 +71,7 @@ describe('Parse Markdown', () => {
     .catch(done);
   });
 
-  it('provides the front-matter attributes', (done) => {
+  it('provides the front-matter attributes', done => {
     parser.parse(mdExample).then(result => {
       result.attributes['test-front-matter'].should.equal('hello world');
     })


### PR DESCRIPTION
# Motive
I'm trying out this loader for my company's react style-guide and would like to get access to the front-matter attributes when loading markdown files

# Todo
- [x] Fixed typo in parser test: `ewual` to `equal`
- [x] export front-matter attributes
- [x] Support all default Prism languages when using fences.
<details>
<summary>
Additional Info
</summary>

> This adds support for things like:
```
    ```bash
    npm install some-package
    ```
    
    # When language is not provided, it still works, similar to how github-md treats fences.
    ```
    some-shell-command a b c
    ```
```
</details>

