### PR TITLE
Prism themes didn't applied correctly

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -20,7 +20,7 @@ function codeBlockTemplate(exampleRun, exampleSrc, langClass) {
 <div class="example">
   <div class="run">${exampleRun}</div>
   <div class="source">
-    <pre><code${!langClass ? '' : ` class="${langClass}"`}>
+    <pre${!langClass ? '' : ` class="${langClass}"`}><code${!langClass ? '' : ` class="${langClass}"`}>
       ${exampleSrc}
     </code></pre>
   </div>


### PR DESCRIPTION
The reason is the missing language-* class on the pre tag.